### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Jekyll 4.4.x static site (personal portfolio/blog). There is no backend, no database, and no external services.
+
+### Quick reference
+
+| Action | Command |
+|--------|---------|
+| Install deps | `bundle install` |
+| Build site | `bundle exec jekyll build` |
+| Dev server | `bundle exec jekyll serve --livereload` |
+| Dev server URL | `http://127.0.0.1:4000/` |
+
+### Environment notes
+
+- Ruby is installed system-wide via `apt` (3.2.x). The `.ruby-version` file says `3.2.10` but any 3.2.x works.
+- Gems are installed to `vendor/bundle` (local path) to avoid permission issues with `/var/lib/gems`. The bundle config is stored in `.bundle/config`.
+- Bundler 4.0.4 is required (matches `Gemfile.lock`).
+- The Sass deprecation warnings during build are expected and non-blocking (upstream theme uses `@import` and legacy Sass APIs).
+- CI validates builds via `.github/workflows/jekyll.yml` — it runs `bundle exec jekyll build`.
+- No lint tool is configured beyond the Jekyll build itself. A successful `jekyll build` is the primary correctness check.
+- `_site/` is gitignored output; `vendor/` is also gitignored.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific development instructions for future agents working on this Jekyll site.

## What's included

- Quick reference table for common commands (install deps, build, dev server)
- Environment notes covering Ruby version, gem installation path, Bundler requirements, Sass deprecation warnings, and CI setup

## Demo

Site running locally with `bundle exec jekyll serve --livereload`:

[Homepage](https://cursor.com/agents/bc-273a4b7a-52ee-48ae-b1e8-a47ab6a18abe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_final.webp)
[Blog post cards](https://cursor.com/agents/bc-273a4b7a-52ee-48ae-b1e8-a47ab6a18abe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_cards.webp)
[Blog post page](https://cursor.com/agents/bc-273a4b7a-52ee-48ae-b1e8-a47ab6a18abe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_post_final.webp)

Build output:
[build_output.log](https://cursor.com/agents/bc-273a4b7a-52ee-48ae-b1e8-a47ab6a18abe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_output.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-273a4b7a-52ee-48ae-b1e8-a47ab6a18abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-273a4b7a-52ee-48ae-b1e8-a47ab6a18abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

